### PR TITLE
[Feature/notice] 공지사항 api 수정 및 버튼 클릭 이벤트로 페이지 이동으로 변경

### DIFF
--- a/src/db/notice.json
+++ b/src/db/notice.json
@@ -5,49 +5,56 @@
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "9999",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": true
         },
         {
             "id": "2",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": false
         },
         {
             "id": "3",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": true
         },
         {
             "id": "4",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": false
         },
         {
             "id": "5",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": false
         },
         {
             "id": "6",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": false
         },
         {
             "id": "7",
             "title": "TITLE ABOUT PLANT RECORDS AND PICTURES",
             "content": "delectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autedelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemdelectus aut autemd",
             "viewCount": "1",
-            "date": "2023-08-03"
+            "date": "2023-08-03",
+            "isHide": false
         }
     ]
 }

--- a/src/dto/notice/notice.dto.ts
+++ b/src/dto/notice/notice.dto.ts
@@ -1,7 +1,7 @@
 import { Expose } from 'class-transformer';
 
 export class NoticeDto {
-    @Expose({ name: 'noticeId' })
+    @Expose({ name: 'id' })
     public readonly id: string = '';
 
     @Expose({ name: 'title' })
@@ -10,12 +10,12 @@ export class NoticeDto {
     @Expose({ name: 'viewCount' })
     public readonly viewCount: string = '';
     
-    @Expose({ name: 'createdAt' })
+    @Expose({ name: 'date' })
     public readonly date: string = '';
 
-    @Expose({ name: 'contents' })
+    @Expose({ name: 'content' })
     public readonly content: string = '';
 
     @Expose({ name: 'isHide'})
-    public readonly isHide: string = '';
+    public readonly isHide: boolean;
 }

--- a/src/views/notice/detail.view.tsx
+++ b/src/views/notice/detail.view.tsx
@@ -28,7 +28,7 @@ const NoticeDetailView = () => {
         noticeViewModel.getMe();
     }, []);
     const offset = noticeViewModel.detail;
-    const isAdmin = noticeViewModel.me.isAdmin || false;
+    const isAdmin = true; //noticeViewModel.me.isAdmin || false;
 
     const handleClickDelete = () => {
         noticeViewModel.deleteList(+id);

--- a/src/views/notice/detail.view.tsx
+++ b/src/views/notice/detail.view.tsx
@@ -48,9 +48,13 @@ const NoticeDetailView = () => {
             <NoticeContent>{offset.content}</NoticeContent>
             {isAdmin && (
                 <div style={{ display: `flex`, marginLeft: `auto`, gap: `16px` }}>
-                    <Linker href={`${pageUrlConfig.noticeEdit}/${id}`}>
-                        <DefaultButton title="수정하기" isPositive={true} />
-                    </Linker>
+                    <DefaultButton
+                        title="수정하기"
+                        isPositive={true}
+                        onClick={() => {
+                            window.location.href = `${pageUrlConfig.noticeEdit}/${id}`;
+                        }}
+                    />
                     <DefaultButton title="삭제하기" isPositive={false} onClick={handleClickDelete} />
                 </div>
             )}

--- a/src/views/notice/edit.view.tsx
+++ b/src/views/notice/edit.view.tsx
@@ -78,7 +78,7 @@ const NoticeEditView = () => {
             date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
             content: content,
             viewCount: '0',
-            isHide: `${checked}`,
+            isHide: checked,
         };
         console.log(detail);
         noticeViewModel.updateList(detail);

--- a/src/views/notice/index.view.tsx
+++ b/src/views/notice/index.view.tsx
@@ -30,7 +30,7 @@ const NoticeView = () => {
     const offset = (page - 1) * limit;
 
     //getMe를 이용해서 등록하기 버튼 분기처리
-    const isAdmin = noticeViewModel.me.isAdmin || false;
+    const isAdmin = true; //noticeViewModel.me.isAdmin || false;
     return (
         <PageContainer>
             <Linker href={`${pageUrlConfig.notice}`}>
@@ -56,9 +56,13 @@ const NoticeView = () => {
             <PageButton limit={limit} target={noticeViewModel.list.length} page={page} setPage={setPage} />
             <div style={{ display: `flex`, marginLeft: `auto` }}>
                 {isAdmin && (
-                    <Linker href={`${pageUrlConfig.noticeUpload}`}>
-                        <DefaultButton title="등록하기" isPositive={true} />
-                    </Linker>
+                    <DefaultButton
+                        title="등록하기"
+                        isPositive={true}
+                        onClick={() => {
+                            window.location.href = `${pageUrlConfig.noticeUpload}`;
+                        }}
+                    />
                 )}
             </div>
         </PageContainer>

--- a/src/views/notice/index.view.tsx
+++ b/src/views/notice/index.view.tsx
@@ -25,12 +25,12 @@ const NoticeView = () => {
     //1. PageButton에 들어갈 상태 - 현재 페이지를 데려옴
     const [page, setPage] = useState<number>(1);
     //2. 한번에 보여줄 리스트 개수
-    const limit = 10;
+    let limit = 2;
     //3. 한번에 보여줄 리스트의 시작지점
     const offset = (page - 1) * limit;
 
     //getMe를 이용해서 등록하기 버튼 분기처리
-    const isAdmin = true; // noticeViewModel.me.isAdmin || false;
+    const isAdmin = noticeViewModel.me.isAdmin || false;
     return (
         <PageContainer>
             <Linker href={`${pageUrlConfig.notice}`}>

--- a/src/views/notice/upload.view.tsx
+++ b/src/views/notice/upload.view.tsx
@@ -71,7 +71,7 @@ const NoticeUploadView = () => {
             date: `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`,
             content: content,
             viewCount: '0',
-            isHide: `${checked}`,
+            isHide: checked,
         };
         console.log(detail);
         noticeViewModel.insertList(detail);


### PR DESCRIPTION
### PR 타입

> 하나 이상의 PR 타입을 선택해주세요.

-   [x] 기능 추가
-   [ ] 기능 삭제
-   [ ] 버그 수정
-   [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### PR 생성 날짜

-   2023/08/23

### 반영 브랜치

-  feature/notice -> dev

### PR 내용

-   `notice.viewModel.ts`내의 api를 수정하여 관리자 계정 외 비공개 게시글 안 보이도록 했습니다
-  기존 버튼에 linker로 연결한 페이지들을 버튼의 클릭 이벤트 발생 시 이동할 수 있도록 수정하였습니다.

### 테스트 결과
- 
### 남은 작업
- 관리자 계정으로 접속할 시 실제로 버튼들이 잘 보이는지 확인이 필요합니다!
현재는 true를 넣어서 했습니다. 확인 후 수정해야 할 코드입니다.
```
const isAdmin = true; //noticeViewModel.me.isAdmin || false;
```
- api가 잘 연결되었는지 확인이 필요합니다!
 현재 db에 연결된 데이터의 형식과 api 형식이 달라 연결시 `noticeDto` 수정해야 합니다.
- 버튼 클릭 이벤트, `notice.viewModel.ts` 에 `window.location`으로 적용한 경로 이동을 `router`로 대체해야 합니다!
